### PR TITLE
feat(DATA-323): add secrets manager backend for airflow connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_principal_arns"></a> [additional\_principal\_arns](#input\_additional\_principal\_arns) | List of additional AWS principal ARNs | `list(string)` | `[]` | no |
 | <a name="input_airflow_configuration_options"></a> [airflow\_configuration\_options](#input\_airflow\_configuration\_options) | (Optional) The airflow\_configuration\_options parameter specifies airflow override options. | `any` | `null` | no |
+| <a name="input_airflow_connection_backend_connection_lookup_pattern"></a> [airflow\_connection\_backend\_connection\_lookup\_pattern](#input\_airflow\_connection\_backend\_connection\_lookup\_pattern) | (Optional) Defines a regex pattern to use for filtering<br/>when listing secrets for Airflow Connections.<br/>Example: ^test | `string` | `"^test"` | no |
+| <a name="input_airflow_connection_backend_connection_prefix"></a> [airflow\_connection\_backend\_connection\_prefix](#input\_airflow\_connection\_backend\_connection\_prefix) | (Optional) Defines the prefix to append after the top level prefix<br/>before prepending the combination to Airflow Connection IDs<br/>when creating entries in AWS Secrets Manager.<br/>Example: my\_top\_level\_prefix/my\_connection\_prefix/my\_prefix\_id | `string` | `"connection"` | no |
+| <a name="input_airflow_connection_backend_top_level_prefix"></a> [airflow\_connection\_backend\_top\_level\_prefix](#input\_airflow\_connection\_backend\_top\_level\_prefix) | (Optional) Defines the prefix the top level prefix<br/>to which the connection and variable prefixes are appended<br/>when creating entries in AWS Secrets Manager<br/>for Airflow Connections and Variables.<br/>Example: my\_top\_level\_prefix/my\_connection\_prefix/my\_prefix\_id | `string` | `"airflow"` | no |
+| <a name="input_airflow_connection_backend_variable_lookup_pattern"></a> [airflow\_connection\_backend\_variable\_lookup\_pattern](#input\_airflow\_connection\_backend\_variable\_lookup\_pattern) | (Optional) Defines a regex pattern to use for filtering<br/>when listing secrets for Airflow Variables.<br/>Example: ^test | `string` | `"^test"` | no |
+| <a name="input_airflow_connection_backend_variable_prefix"></a> [airflow\_connection\_backend\_variable\_prefix](#input\_airflow\_connection\_backend\_variable\_prefix) | (Optional) Defines the prefix to append after the top level prefix<br/>before prepending the combination to Airflow Variable Names<br/>when creating entries in AWS Secrets Manager.<br/>Example: my\_top\_level\_prefix/my\_connection\_prefix/my\_variable\_name | `string` | `"variable"` | no |
 | <a name="input_airflow_version"></a> [airflow\_version](#input\_airflow\_version) | (Optional) Airflow version of your environment, will be set by default to the latest version that MWAA supports. | `string` | `null` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Create IAM role for MWAA | `bool` | `true` | no |
 | <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | Create new S3 bucket for MWAA. | `string` | `true` | no |
@@ -190,6 +195,7 @@ No modules.
 |------|-------------|
 | <a name="output_aws_s3_bucket_name"></a> [aws\_s3\_bucket\_name](#output\_aws\_s3\_bucket\_name) | S3 bucket Name of the MWAA Environment |
 | <a name="output_mwaa_arn"></a> [mwaa\_arn](#output\_mwaa\_arn) | The ARN of the MWAA Environment |
+| <a name="output_mwaa_connections_prefix"></a> [mwaa\_connections\_prefix](#output\_mwaa\_connections\_prefix) | Secrets Manager secrets prefix for MWAA Airflow Connections |
 | <a name="output_mwaa_dag_processing_cloudwatch_log_group_arn"></a> [mwaa\_dag\_processing\_cloudwatch\_log\_group\_arn](#output\_mwaa\_dag\_processing\_cloudwatch\_log\_group\_arn) | CloudWatch Log Group ARN for Apache Airflow DAG Processing Logs |
 | <a name="output_mwaa_role_arn"></a> [mwaa\_role\_arn](#output\_mwaa\_role\_arn) | IAM Role ARN of the MWAA Environment |
 | <a name="output_mwaa_role_name"></a> [mwaa\_role\_name](#output\_mwaa\_role\_name) | IAM role name of the MWAA Environment |
@@ -198,6 +204,7 @@ No modules.
 | <a name="output_mwaa_service_role_arn"></a> [mwaa\_service\_role\_arn](#output\_mwaa\_service\_role\_arn) | The Service Role ARN of the Amazon MWAA Environment |
 | <a name="output_mwaa_status"></a> [mwaa\_status](#output\_mwaa\_status) | The status of the Amazon MWAA Environment |
 | <a name="output_mwaa_task_log_group_arn"></a> [mwaa\_task\_log\_group\_arn](#output\_mwaa\_task\_log\_group\_arn) | CloudWatch Log Group ARN for Apache Airflow Task Logs |
+| <a name="output_mwaa_variables_prefix"></a> [mwaa\_variables\_prefix](#output\_mwaa\_variables\_prefix) | Secrets Manager secrets prefix for MWAA Airflow Variables |
 | <a name="output_mwaa_webserver_log_group_arn"></a> [mwaa\_webserver\_log\_group\_arn](#output\_mwaa\_webserver\_log\_group\_arn) | CloudWatch Log Group ARN for Apache Airflow Webserver Logs |
 | <a name="output_mwaa_webserver_url"></a> [mwaa\_webserver\_url](#output\_mwaa\_webserver\_url) | The webserver URL of the MWAA Environment |
 | <a name="output_mwaa_webserver_vpc_endpoint_service"></a> [mwaa\_webserver\_vpc\_endpoint\_service](#output\_mwaa\_webserver\_vpc\_endpoint\_service) | The VPC endpoint for the environment's web server |

--- a/data.tf
+++ b/data.tf
@@ -9,6 +9,7 @@ data "aws_caller_identity" "current" {}
 # ---------------------------------------------------------------------------------------------------------------------
 data "aws_iam_policy_document" "mwaa_assume" {
   statement {
+    sid     = "AllowAssumeRoleForMWAAServices"
     actions = ["sts:AssumeRole"]
 
     principals {
@@ -50,6 +51,7 @@ data "aws_iam_policy_document" "mwaa_assume" {
 #tfsec:ignore:AWS099
 data "aws_iam_policy_document" "mwaa" {
   statement {
+    sid    = "AllowCreateAirflowLogin"
     effect = "Allow"
     actions = [
       "airflow:PublishMetrics",
@@ -60,6 +62,7 @@ data "aws_iam_policy_document" "mwaa" {
     ]
   }
   statement {
+    sid    = "AllowReadS3SourceBucket"
     effect = "Allow"
     actions = [
       "s3:GetObject*",
@@ -73,6 +76,7 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
+    sid    = "AllowReadAirflowLogs"
     effect = "Allow"
     actions = [
       "logs:CreateLogStream",
@@ -89,6 +93,7 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
+    sid    = "AllowReadMetadata"
     effect = "Allow"
     actions = [
       "logs:DescribeLogGroups",
@@ -102,6 +107,7 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
+    sid    = "AllowControlSQS"
     effect = "Allow"
     actions = [
       "sqs:ChangeMessageVisibility",
@@ -123,6 +129,7 @@ data "aws_iam_policy_document" "mwaa" {
   dynamic "statement" {
     for_each = var.kms_key != null ? [] : [1]
     content {
+      sid    = "AllowKmsEncrypt"
       effect = "Allow"
       actions = [
         "kms:Decrypt",
@@ -147,6 +154,7 @@ data "aws_iam_policy_document" "mwaa" {
   dynamic "statement" {
     for_each = var.kms_key != null ? [1] : []
     content {
+      sid    = "AllowKMSEncrypt"
       effect = "Allow"
       actions = [
         "kms:Decrypt",
@@ -169,6 +177,7 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
+    sid    = "AllowAllOnAWSBatch"
     effect = "Allow"
     actions = [
       "batch:*",
@@ -179,6 +188,7 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
+    sid    = "AllowAllOnSSMParameters"
     effect = "Allow"
     actions = [
       "ssm:*"
@@ -189,7 +199,8 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
-    effect = "Allow"
+    sid    = "AllowAllOnLambda"
+    effect = "AllowAllLogsOnLambdaLogs"
     actions = [
       "logs:*"
     ]
@@ -197,8 +208,25 @@ data "aws_iam_policy_document" "mwaa" {
   }
 
   statement {
+    sid       = "AllowAllCloudWatchOnLambdaLogs"
     effect    = "Allow"
     actions   = ["cloudwatch:*"]
     resources = ["arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/*"]
+  }
+
+  statement {
+    sid    = "AirflowConnectionBackendReadOnly"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:BatchGetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:ListSecretVersionIds",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.id}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.airflow_connection_backend_top_level_prefix}/${var.airflow_connection_backend_connection_prefix}/*",
+      "arn:${data.aws_partition.current.id}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.airflow_connection_backend_top_level_prefix}/${var.airflow_connection_backend_variable_prefix}/*"
+    ]
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,17 @@ locals {
     "logging.logging_level" = "INFO"
   }
 
-  airflow_configuration_options = merge(local.default_airflow_configuration_options, var.airflow_configuration_options)
+  airflow_secrets_manager_backend_configuration_options = {
+    "secrets.backend" = "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend"
+    "secrets.backend_kwargs" = {
+      "connections_prefix"         = "${var.airflow_connection_backend_top_level_prefix}/${var.airflow_connection_backend_connection_prefix}",
+      "connections_lookup_pattern" = "${var.airflow_connection_backend_connection_lookup_pattern}",
+      "variables_prefix"           = "${var.airflow_connection_backend_top_level_prefix}/${var.airflow_connection_backend_variable_prefix}",
+      "variables_lookup_pattern"   = "${var.airflow_connection_backend_variable_lookup_pattern}"
+    }
+  }
+
+  airflow_configuration_options = merge(local.default_airflow_configuration_options, local.airflow_secrets_manager_backend_configuration_options, var.airflow_configuration_options)
 
   iam_role_additional_policies = { for k, v in var.iam_role_additional_policies : k => v if var.create_iam_role }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,3 +68,12 @@ output "mwaa_worker_log_group_arn" {
   value       = try(aws_mwaa_environment.mwaa.logging_configuration[0].worker_logs[0].cloud_watch_log_group_arn, null)
 }
 
+output "mwaa_connections_prefix" {
+  description = "Secrets Manager secrets prefix for MWAA Airflow Connections"
+  value       = "${var.airflow_connection_backend_top_level_prefix}/${var.airflow_connection_backend_connection_prefix}"
+}
+
+output "mwaa_variables_prefix" {
+  description = "Secrets Manager secrets prefix for MWAA Airflow Variables"
+  value       = "${var.airflow_connection_backend_top_level_prefix}/${var.airflow_connection_backend_variable_prefix}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -296,3 +296,57 @@ variable "source_cidr" {
   type        = list(string)
   default     = []
 }
+
+variable "airflow_connection_backend_top_level_prefix" {
+  description = <<-EOD
+  (Optional) Defines the prefix the top level prefix
+  to which the connection and variable prefixes are appended
+  when creating entries in AWS Secrets Manager
+  for Airflow Connections and Variables.
+  Example: my_top_level_prefix/my_connection_prefix/my_prefix_id
+  EOD
+  type        = string
+  default     = "airflow"
+}
+
+variable "airflow_connection_backend_connection_prefix" {
+  description = <<-EOD
+  (Optional) Defines the prefix to append after the top level prefix
+  before prepending the combination to Airflow Connection IDs
+  when creating entries in AWS Secrets Manager.
+  Example: my_top_level_prefix/my_connection_prefix/my_prefix_id
+  EOD
+  type        = string
+  default     = "connection"
+}
+
+variable "airflow_connection_backend_connection_lookup_pattern" {
+  description = <<-EOD
+  (Optional) Defines a regex pattern to use for filtering
+  when listing secrets for Airflow Connections.
+  Example: ^test
+  EOD
+  type        = string
+  default     = "^test"
+}
+
+variable "airflow_connection_backend_variable_prefix" {
+  description = <<-EOD
+  (Optional) Defines the prefix to append after the top level prefix
+  before prepending the combination to Airflow Variable Names
+  when creating entries in AWS Secrets Manager.
+  Example: my_top_level_prefix/my_connection_prefix/my_variable_name
+  EOD
+  type        = string
+  default     = "variable"
+}
+
+variable "airflow_connection_backend_variable_lookup_pattern" {
+  description = <<-EOD
+  (Optional) Defines a regex pattern to use for filtering
+  when listing secrets for Airflow Variables.
+  Example: ^test
+  EOD
+  type        = string
+  default     = "^test"
+}


### PR DESCRIPTION
- adds IAM policy statements to MWAA executor role for accessing Airflow Connections and Variables secrets
- adds tf vars to allow users to configure the prefix of connections and variables
- adds tf vars to allow users to configure a lookup pattern for connections and variables
- adds airflow configuration settings to use AWS Secrets Manager backend unless overridden by module caller
- constrains module callers to install up-to-date AWS provider for Airflow per [docs](https://docs.aws.amazon.com/mwaa/latest/userguide/connections-secrets-manager.html)